### PR TITLE
Add interactive location selection

### DIFF
--- a/lib/ride_map_screen.dart
+++ b/lib/ride_map_screen.dart
@@ -88,7 +88,17 @@ class _RideMapScreenState extends State<RideMapScreen> {
           target: clientLatLng,
           zoom: 15,
         ),
+        myLocationEnabled: true,
+        myLocationButtonEnabled: true,
         onMapCreated: (controller) => _mapController = controller,
+        onTap: (LatLng pos) {
+          setState(() {
+            _clientLocation = LocationData.fromMap({
+              'latitude': pos.latitude,
+              'longitude': pos.longitude,
+            });
+          });
+        },
         markers: _buildMarkers(clientLatLng),
       ),
     );


### PR DESCRIPTION
## Summary
- show my location on service map
- allow tapping the map to set the client location

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684319869d28832998d79a79d6ba6b7e