### PR TITLE
Add profile editing with photo upload

### DIFF
--- a/lib/edit_profile_screen.dart
+++ b/lib/edit_profile_screen.dart
@@ -1,4 +1,9 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 
 class EditProfileScreen extends StatefulWidget {
   const EditProfileScreen({super.key});
@@ -8,9 +13,33 @@ class EditProfileScreen extends StatefulWidget {
 }
 
 class _EditProfileScreenState extends State<EditProfileScreen> {
-  final TextEditingController _nameController = TextEditingController(text: "John Doe");
-  final TextEditingController _phoneController = TextEditingController(text: "+1234567890");
-  final TextEditingController _emailController = TextEditingController(text: "john.doe@example.com");
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _phoneController = TextEditingController();
+  final TextEditingController _emailController = TextEditingController();
+
+  String? _photoUrl;
+  File? _newPhoto;
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadProfile();
+  }
+
+  Future<void> _loadProfile() async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return;
+    final doc = await FirebaseFirestore.instance.collection('users').doc(uid).get();
+    final data = doc.data();
+    if (data != null) {
+      _nameController.text = data['name'] ?? '';
+      _phoneController.text = data['phone'] ?? '';
+      _emailController.text = data['email'] ?? '';
+      _photoUrl = data['photoUrl'];
+      setState(() {});
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -23,6 +52,19 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
         padding: const EdgeInsets.all(24.0),
         child: Column(
           children: [
+            GestureDetector(
+              onTap: _pickImage,
+              child: CircleAvatar(
+                radius: 45,
+                backgroundColor: Colors.grey[200],
+                backgroundImage:
+                    _newPhoto != null ? FileImage(_newPhoto!) : (_photoUrl != null ? NetworkImage(_photoUrl!) as ImageProvider : null),
+                child: (_newPhoto == null && _photoUrl == null)
+                    ? const Icon(Icons.camera_alt, size: 32, color: Colors.grey)
+                    : null,
+              ),
+            ),
+            const SizedBox(height: 16),
             TextField(
               controller: _nameController,
               decoration: const InputDecoration(
@@ -53,13 +95,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
             ),
             const Spacer(),
             ElevatedButton(
-              onPressed: () {
-                // Здесь можно добавить сохранение в Firebase или локально
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Profile updated successfully')),
-                );
-                Navigator.of(context).pop();
-              },
+              onPressed: _saveProfile,
               style: ElevatedButton.styleFrom(
                 backgroundColor: Colors.deepPurple,
                 minimumSize: const Size(double.infinity, 50),
@@ -76,5 +112,44 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
         ),
       ),
     );
+  }
+
+  Future<void> _pickImage() async {
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(source: ImageSource.gallery, imageQuality: 75);
+    if (picked != null) {
+      setState(() {
+        _newPhoto = File(picked.path);
+      });
+    }
+  }
+
+  Future<void> _saveProfile() async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return;
+
+    setState(() => _loading = true);
+    String? photoUrl = _photoUrl;
+
+    if (_newPhoto != null) {
+      final ref = FirebaseStorage.instance.ref().child('user_photos/$uid.jpg');
+      await ref.putFile(_newPhoto!);
+      photoUrl = await ref.getDownloadURL();
+    }
+
+    await FirebaseFirestore.instance.collection('users').doc(uid).update({
+      'name': _nameController.text.trim(),
+      'phone': _phoneController.text.trim(),
+      'email': _emailController.text.trim(),
+      'photoUrl': photoUrl,
+    });
+
+    if (mounted) {
+      setState(() => _loading = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Profile updated successfully')),
+      );
+      Navigator.of(context).pop();
+    }
   }
 }

--- a/lib/main_swipe_ui.dart
+++ b/lib/main_swipe_ui.dart
@@ -75,7 +75,12 @@ class _SwipeHomeState extends State<SwipeHome> {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Image.asset(page.iconPath, height: 120),
+                    Image.asset(
+                      page.iconPath,
+                      height: 120,
+                      errorBuilder: (_, __, ___) =>
+                          const Icon(Icons.broken_image, size: 120),
+                    ),
                     const SizedBox(height: 20),
                     Text(page.title, style: Theme.of(context).textTheme.headlineMedium),
                     const SizedBox(height: 10),

--- a/lib/swipe_home.dart
+++ b/lib/swipe_home.dart
@@ -75,7 +75,12 @@ class _SwipeHomeState extends State<SwipeHome> {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Image.asset(page.iconPath, height: 120),
+                    Image.asset(
+                      page.iconPath,
+                      height: 120,
+                      errorBuilder: (_, __, ___) =>
+                          const Icon(Icons.broken_image, size: 120),
+                    ),
                     const SizedBox(height: 20),
                     Text(page.title,
                         style: Theme.of(context).textTheme.headlineMedium),

--- a/lib/user_account_screen.dart
+++ b/lib/user_account_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'edit_profile_screen.dart';
 
 class UserAccountScreen extends StatelessWidget {
@@ -7,32 +8,46 @@ class UserAccountScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final user = FirebaseAuth.instance.currentUser;
+    final uid = FirebaseAuth.instance.currentUser?.uid;
 
-    return Container(
-      padding: const EdgeInsets.all(24),
-      decoration: const BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const Icon(Icons.drag_handle, color: Colors.grey),
-          const SizedBox(height: 16),
-          CircleAvatar(
-            radius: 40,
-            backgroundColor: Colors.deepPurple,
-            child: Text(
-              user?.email?.substring(0, 1).toUpperCase() ?? '?',
-              style: const TextStyle(fontSize: 32, color: Colors.white),
-            ),
+    return FutureBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+      future: uid == null
+          ? null
+          : FirebaseFirestore.instance.collection('users').doc(uid).get(),
+      builder: (context, snapshot) {
+        final data = snapshot.data?.data();
+        final email = FirebaseAuth.instance.currentUser?.email ?? 'No email';
+        final photoUrl = data?['photoUrl'] as String?;
+        final name = data?['name'] ?? email;
+        return Container(
+          padding: const EdgeInsets.all(24),
+          decoration: const BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
           ),
-          const SizedBox(height: 16),
-          Text(
-            user?.email ?? 'No email',
-            style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.drag_handle, color: Colors.grey),
+              const SizedBox(height: 16),
+              CircleAvatar(
+                radius: 40,
+                backgroundColor: Colors.deepPurple,
+                backgroundImage: photoUrl != null ? NetworkImage(photoUrl) : null,
+                child: photoUrl == null
+                    ? Text(
+                        email.substring(0, 1).toUpperCase(),
+                        style:
+                            const TextStyle(fontSize: 32, color: Colors.white),
+                      )
+                    : null,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                name,
+                style:
+                    const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
           const SizedBox(height: 24),
           ElevatedButton.icon(
             onPressed: () {
@@ -71,5 +86,7 @@ class UserAccountScreen extends StatelessWidget {
         ],
       ),
     );
-  }
+  },
+);
+}
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
   geolocator: ^10.1.0
   geocoding: ^2.1.0
   cupertino_icons: ^1.0.8
+  firebase_storage: ^11.7.4
+  image_picker: ^1.0.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `firebase_storage` and `image_picker` packages
- enable photo selection and upload in `EditProfileScreen`
- load and save user profile data in Firestore
- display uploaded avatar in `UserAccountScreen`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684451db0ed08329a65dbcf809bc5f89